### PR TITLE
Fix stage-race scrapers, model team time trials, dedup podium picks

### DIFF
--- a/scripts/render_stagerace.jl
+++ b/scripts/render_stagerace.jl
@@ -173,7 +173,8 @@ if using_per_stage
             "HC", "Cat1", "Likely 1st", "Likely 2nd", "Likely 3rd",
         ]
         write(io, html_callout(
-            "<p>Most likely podium finishers per stage, alongside basic stage details. Probabilities in parentheses are the share of $(diagnostics.n_sims) simulations in which the named rider finished in that exact position.</p>\n" *
+            "<p>Most likely podium finishers per stage, alongside basic stage details. Probabilities in parentheses are the share of $(diagnostics.n_sims) simulations in which the named rider finished in that exact position. Each column names a distinct rider (the modal occupant of that position, excluding riders already shown to its left).</p>\n" *
+            "<p><em>Caveat:</em> the simulation does not model breakaway wins, which take a large share of real hilly and mountain stages. Treat these as the favourites' odds <em>conditional on the stage being contested by the front group</em> — actual single-stage win rates are lower and more spread out.</p>\n" *
             html_table(stage_df[:, stage_col_order]);
             title="Stage details and podium picks", collapsed=false))
     end

--- a/src/get_data.jl
+++ b/src/get_data.jl
@@ -387,11 +387,14 @@ function parse_oddschecker_odds(text::String)
         tokens = split(line, '\t')
         non_empty = [strip(t) for t in tokens if !isempty(strip(t))]
         length(non_empty) < 2 && return false
-        all(to_decimal(t) !== nothing for t in non_empty) || return false
-        length(non_empty) >= 3 && return true
-        # Two-token line: only accept if both decode to the same value
-        decs = to_decimal.(non_empty)
-        return decs[1] == decs[2]
+        valid = Float64[d for d in (to_decimal(t) for t in non_empty) if d !== nothing]
+        # Tolerate a minority of junk tokens (e.g. "9/2Bet" where a bookmaker's
+        # "Bet" button label glues onto the price, "100/ 30" with stray spaces).
+        # A genuine bookmaker row has many price columns, so ≥3 decodable odds is
+        # a reliable signal; downstream parsing re-filters the junk tokens.
+        length(valid) >= 3 && return true
+        # Two-token line: only accept if every token decodes and both agree
+        length(valid) == length(non_empty) && length(valid) == 2 && valid[1] == valid[2]
     end
 
     lines = split(replace(text, "\r\n" => "\n", "\r" => "\n"), '\n')
@@ -484,16 +487,19 @@ function get_cycling_oracle(
     function fetch_oracle(_url, params)
         url = params["prediction_url"]
         response = HTTP.get(url, ["User-Agent" => "Mozilla/5.0 (compatible; Velogames.jl)"])
-        html = String(response.body)
+        page = Gumbo.parsehtml(String(response.body))
 
-        # Extract embedded JSON: var riders2D = JSON.parse(`[...]`)
-        m = match(r"var riders2D = JSON\.parse\(`(.*?)`\)", html)
-        if m === nothing
+        # Predictions are embedded as HTML-entity-encoded JSON in a
+        # `data-prediction-config` attribute (Gumbo decodes the entities for us).
+        # The decoded object holds a `predictions` array of rider entries.
+        cfg_nodes = eachmatch(Selector("[data-prediction-config]"), page.root)
+        if isempty(cfg_nodes)
             @warn "Could not find prediction data in Cycling Oracle page: $url"
             return DataFrame(rider=String[], win_prob=Float64[], riderkey=String[])
         end
 
-        data = JSON3.read(m.captures[1])
+        config = JSON3.read(cfg_nodes[1].attributes["data-prediction-config"])
+        data = get(config, :predictions, ())
 
         names_out = String[]
         probs_out = Float64[]
@@ -821,6 +827,72 @@ end
 Scrape the VG scoring rules from scores.php for a stage race.
 Archives the result if `pcs_slug` is provided. Loads from archive if available.
 """
+# Map a VG scores.php section heading (the <b>/<h3> text above each table) to
+# the scoring field it populates. Heading-based mapping is robust to the table
+# count/order changing between years — e.g. the 2026 Tour opens with a TTT, so
+# VG inserts two extra "Team Time Trial" tables at the front that would shift a
+# positional mapping by +2 (silently corrupting final_gc_points, etc.).
+function _vg_scoring_field(heading::AbstractString)
+    l = lowercase(heading)
+    # Team time trial: the stage-result table feeds ttt_team_points; the
+    # "overall leader" bonus table is not modelled.
+    occursin("team time trial", l) && occursin("stage result", l) && return :ttt_team_points
+    occursin("team time trial", l) && return nothing
+    occursin("stage result", l) && return :stage_finish_points
+    if occursin("final", l)
+        occursin("general classification", l) && return :final_gc_points
+        occursin("points", l) && return :final_points_class
+        occursin("mountains", l) && return :final_mountains_class
+        occursin("team", l) && return :final_team_class
+    end
+    if occursin("assist", l)
+        occursin("general classification", l) && return :gc_assist_points
+        occursin("team", l) && return :team_class_assist_points
+        occursin("stage", l) && return :stage_assist_points
+    end
+    occursin("intermediate sprint", l) && return :intermediate_sprint_points
+    occursin("hc category", l) && return :hc_climb_points
+    occursin("1st category", l) && return :cat1_climb_points
+    occursin("breakaway", l) && return :breakaway_points
+    occursin("general classification", l) && return :daily_gc_points
+    occursin("points classification", l) && return :daily_points_class
+    occursin("mountains classification", l) && return :daily_mountains_class
+    return nothing
+end
+
+# Last integer-valued cell in each table row (skips the "Position" column and
+# the non-numeric header row).
+function _vg_table_points(table)
+    pts = Int[]
+    for row in eachmatch(Selector("tr"), table)
+        for cell in reverse(collect(eachmatch(Selector("td"), row)))
+            txt = strip(nodeText(cell))
+            if occursin(r"^-?\d+$", txt)
+                push!(pts, parse(Int, txt))
+                break
+            end
+        end
+    end
+    pts
+end
+
+# Walk the DOM in document order, pairing each <table> with the most recent
+# <b>/<h3> heading text seen before it.
+function _vg_walk_scoring(node, heading::Ref{String}, out::Vector{Tuple{String,Vector{Int}}})
+    node isa Gumbo.HTMLElement || return
+    t = Gumbo.tag(node)
+    if t == :b || t == :h3
+        txt = strip(nodeText(node))
+        isempty(txt) || (heading[] = txt)
+    elseif t == :table
+        push!(out, (heading[], _vg_table_points(node)))
+        return  # don't descend into table internals
+    end
+    for child in node.children
+        _vg_walk_scoring(child, heading, out)
+    end
+end
+
 function getvg_scoring(vg_slug::String, year::Int; pcs_slug::String="")
     if !isempty(pcs_slug)
         archived = load_race_snapshot("vg_scoring", pcs_slug, year)
@@ -830,25 +902,31 @@ function getvg_scoring(vg_slug::String, year::Int; pcs_slug::String="")
     end
 
     url = "https://www.velogames.com/$vg_slug/$year/scores.php"
-    tables = scrape_html_tables(url)
+    response = HTTP.get(url, ["User-Agent" => "Mozilla/5.0 (compatible; VelogamesBot/1.0)"])
+    page = Gumbo.parsehtml(String(response.body))
 
-    _pts(df) = [parse(Int, replace(string(row.Points), r"[^0-9]" => ""))
-                for row in eachrow(df)]
+    pairs = Tuple{String,Vector{Int}}[]
+    _vg_walk_scoring(page.root, Ref(""), pairs)
 
-    get_table(i) = i <= length(tables) ? _pts(tables[i]) : Int[]
-
-    breakaway = if 8 <= length(tables) && nrow(tables[8]) > 0
-        parse(Int, replace(string(tables[8][1, :Points]), r"[^0-9]" => ""))
-    else
-        0
+    fields = Dict{Symbol,Vector{Int}}()
+    for (heading, pts) in pairs
+        isempty(pts) && continue
+        field = _vg_scoring_field(heading)
+        (field === nothing || haskey(fields, field)) && continue  # first match wins
+        fields[field] = pts
     end
 
+    get_vec(f) = get(fields, f, Int[])
+    bp = haskey(fields, :breakaway_points) ? fields[:breakaway_points][1] : 0
     scoring = StageRaceScoringTable(
-        get_table(1), get_table(2), get_table(3), get_table(4),
-        get_table(5), get_table(6), get_table(7), breakaway,
-        get_table(9), get_table(10), get_table(11), get_table(12),
-        get_table(13), get_table(14), get_table(15),
-        length(tables) >= 16 ? get_table(16) : Int[],
+        get_vec(:stage_finish_points), get_vec(:daily_gc_points),
+        get_vec(:daily_points_class), get_vec(:daily_mountains_class),
+        get_vec(:intermediate_sprint_points), get_vec(:hc_climb_points),
+        get_vec(:cat1_climb_points), bp,
+        get_vec(:stage_assist_points), get_vec(:gc_assist_points),
+        get_vec(:team_class_assist_points), get_vec(:final_gc_points),
+        get_vec(:final_points_class), get_vec(:final_mountains_class),
+        get_vec(:final_team_class), get_vec(:ttt_team_points),
     )
 
     if !isempty(pcs_slug)

--- a/src/report_helpers.jl
+++ b/src/report_helpers.jl
@@ -1626,16 +1626,34 @@ function format_stage_podium_picks(
     rider_names = String.(riders.rider)
     n_sims = diagnostics.n_sims
 
-    function _pick(stage_idx::Int, rank::Int)
-        counts = diagnostics.stage_finish_counts[stage_idx, :, rank]
-        i = argmax(counts)
-        prob = counts[i] / n_sims
-        prob < 0.005 && return ""
-        return "$(rider_names[i]) ($(round(Int, 100 * prob))%)"
+    # Pick the modal occupant of each podium position, but exclude riders
+    # already shown in a higher column so the three cells name distinct riders
+    # (a dominant favourite is otherwise the modal occupant of 1st, 2nd AND 3rd,
+    # which just repeats one name). The percentage is still P(rider finishes in
+    # exactly that position).
+    function _picks(stage_idx::Int)
+        used = Int[]
+        out = String[]
+        for rank in 1:3
+            counts = copy(diagnostics.stage_finish_counts[stage_idx, :, rank])
+            for u in used
+                counts[u] = -1
+            end
+            i = argmax(counts)
+            prob = counts[i] / n_sims
+            if counts[i] <= 0 || prob < 0.005
+                push!(out, "")
+            else
+                push!(used, i)
+                push!(out, "$(rider_names[i]) ($(round(Int, 100 * prob))%)")
+            end
+        end
+        return out
     end
 
     rows = Dict{String,Any}[]
     for (idx, s) in enumerate(stages)
+        picks = _picks(idx)
         push!(rows, Dict{String,Any}(
             "Stage" => s.stage_number,
             "Type" => String(s.stage_type),
@@ -1645,9 +1663,9 @@ function format_stage_podium_picks(
             "Summit" => s.is_summit_finish ? "Yes" : "",
             "HC" => s.n_hc_climbs > 0 ? string(s.n_hc_climbs) : "",
             "Cat1" => s.n_cat1_climbs > 0 ? string(s.n_cat1_climbs) : "",
-            "Likely 1st" => _pick(idx, 1),
-            "Likely 2nd" => _pick(idx, 2),
-            "Likely 3rd" => _pick(idx, 3),
+            "Likely 1st" => picks[1],
+            "Likely 2nd" => picks[2],
+            "Likely 3rd" => picks[3],
         ))
     end
     return DataFrame(rows)

--- a/src/scoring.jl
+++ b/src/scoring.jl
@@ -48,9 +48,9 @@ struct StageRaceScoringTable
     breakaway_points::Int                    # points per rider in break at 50%
 
     # Assist points (stage finish, GC, team classification)
-    stage_assist_points::Vector{Int}         # length 3: teammate in stage top 3
-    gc_assist_points::Vector{Int}            # length 3: teammate in GC top 3
-    team_class_assist_points::Vector{Int}    # length 3: team in team class top 3
+    stage_assist_points::Vector{Int}         # teammate in stage top N (length varies by scraped scoring)
+    gc_assist_points::Vector{Int}            # teammate in GC top N (length varies by scraped scoring)
+    team_class_assist_points::Vector{Int}    # team in team class top N (length varies by scraped scoring)
 
     # Final classification bonuses (end of race)
     final_gc_points::Vector{Int}             # length 30: final GC positions 1-30

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -1339,9 +1339,10 @@ end
     for i in 1:n_riders
         stage_pts[i] += daily_gc_points_for_position(gc_positions[i], scoring)
     end
-    if stype != :itt && stype != :ttt
+    assist_depth = length(scoring.gc_assist_points)
+    if stype != :itt && stype != :ttt && assist_depth > 0
         for i in 1:n_riders
-            if gc_positions[i] <= 3
+            if gc_positions[i] <= assist_depth
                 for j in 1:n_riders
                     if j != i && teams[j] == teams[i]
                         stage_pts[j] += scoring.gc_assist_points[gc_positions[i]]
@@ -1349,6 +1350,48 @@ end
                 end
             end
         end
+    end
+    return nothing
+end
+
+# Team time trial: the whole squad rides together and shares one result, so the
+# outcome is a ranking of TEAMS (by mean TT strength), not individuals. Every
+# rider takes their team's placing as their finishing position.
+function _assign_team_positions!(
+    positions::Vector{Int},
+    noisy::Vector{Float64},
+    teams::Vector{String},
+    n_riders::Int,
+)
+    team_sum = Dict{String,Float64}()
+    team_n = Dict{String,Int}()
+    for i in 1:n_riders
+        team_sum[teams[i]] = get(team_sum, teams[i], 0.0) + noisy[i]
+        team_n[teams[i]] = get(team_n, teams[i], 0) + 1
+    end
+    ranked = sort(collect(keys(team_sum)), by=t -> team_sum[t] / team_n[t], rev=true)
+    team_rank = Dict(t => r for (r, t) in enumerate(ranked))
+    for i in 1:n_riders
+        positions[i] = team_rank[teams[i]]
+    end
+    return nothing
+end
+
+# Score a team time trial: every rider earns the points for their team's
+# placing. Uses the dedicated `ttt_team_points` table, falling back to the
+# normal stage-finish table if VG published no TTT-specific scoring.
+@inline function _score_ttt_team!(
+    stage_pts::Vector{Float64},
+    positions::Vector{Int},
+    scoring::StageRaceScoringTable,
+    n_riders::Int,
+)
+    fill!(stage_pts, 0.0)
+    pts_table = isempty(scoring.ttt_team_points) ? scoring.stage_finish_points :
+                scoring.ttt_team_points
+    depth = length(pts_table)
+    for i in 1:n_riders
+        positions[i] <= depth && (stage_pts[i] += pts_table[positions[i]])
     end
     return nothing
 end
@@ -1444,10 +1487,14 @@ function stage_dimension_weights(stage::StageProfile)
                                                (flat=0.0, hilly=1.0, mountain=0.0, itt=0.0)
     end
     ps = Float64(stage.profile_score)
-    if ps <= 20.0
+    # Flat-to-hilly ramp starts at PS 40 (not 20): a rolling sprint stage with a
+    # modest ProfileScore (~50-60) is still won by sprinters in a bunch finish,
+    # so it should stay majority-flat rather than tipping puncheurs/GC riders
+    # onto the podium. PS 58 → ~64% flat / 36% hilly.
+    if ps <= 40.0
         f, h, m = 1.0, 0.0, 0.0
     elseif ps <= 90.0
-        h = (ps - 20.0) / 70.0
+        h = (ps - 40.0) / 50.0
         f = 1.0 - h
         m = 0.0
     elseif ps <= 250.0
@@ -1582,9 +1629,15 @@ function simulate_stage_race(
             end
 
             # Rank by noisy stage strength → positions, record podium/top-10.
+            # A team time trial is scored as a ranking of teams: every rider
+            # shares their squad's placing.
             order = sortperm(noisy, rev=true)
-            for (pos, rider_idx) in enumerate(order)
-                positions[rider_idx] = pos
+            if stype == :ttt
+                _assign_team_positions!(positions, noisy, teams, n_riders)
+            else
+                for (pos, rider_idx) in enumerate(order)
+                    positions[rider_idx] = pos
+                end
             end
             for i in 1:n_riders
                 p = positions[i]
@@ -1596,7 +1649,11 @@ function simulate_stage_race(
                 end
             end
 
-            _score_stage_finish_and_assists!(stage_pts, positions, teams, scoring, stype, n_riders)
+            if stype == :ttt
+                _score_ttt_team!(stage_pts, positions, scoring, n_riders)
+            else
+                _score_stage_finish_and_assists!(stage_pts, positions, teams, scoring, stype, n_riders)
+            end
 
             # Cumulative GC ranking after this stage.
             gc_order = sortperm(cumulative_gc_score, rev=true)
@@ -1634,7 +1691,7 @@ function simulate_stage_race(
 
         # Final points classification (Tipo A/B/C-weighted points-jersey total)
         sprint_order = sortperm(points_jersey_total, rev=true)
-        for rank in 1:min(10, n_riders)
+        for rank in 1:min(length(scoring.final_points_class), n_riders)
             rider_idx = sprint_order[rank]
             if points_jersey_total[rider_idx] > 0
                 rider_total_pts[rider_idx] += scoring.final_points_class[rank]
@@ -1646,7 +1703,7 @@ function simulate_stage_race(
 
         # Final mountains classification (mountain top-5 count proxy)
         kom_order = sortperm(mountain_top5_counts, rev=true)
-        for rank in 1:min(10, n_riders)
+        for rank in 1:min(length(scoring.final_mountains_class), n_riders)
             rider_idx = kom_order[rank]
             if mountain_top5_counts[rider_idx] > 0
                 rider_total_pts[rider_idx] += scoring.final_mountains_class[rank]


### PR DESCRIPTION
Validated bug-fixes split out from the GT cross-history experiment branch so they can land on `main` independently.

## What's in here

**`fix: harden odds, oracle, and VG scoring scrapers`**
- Cycling Oracle: site moved its data from a `var riders2D = JSON.parse(...)` script into an entity-encoded `data-prediction-config` attribute; parse it via Gumbo + the `predictions` array.
- VG scoring (`getvg_scoring`): map `scores.php` tables by their section heading instead of absolute index. The 2026 Tour adds two TTT tables at the front, which shifted a positional mapping by +2 and silently loaded a `[8,4,2]` assists table into `final_gc_points` (should be `[600,…]`) — gutting every GC rider's predicted points (~4× too low). Also captures `ttt_team_points`.
- Oddschecker parser: a single junk token (`9/2Bet`, a "Bet" button label glued onto a price) made `is_multi_odds_line` reject the whole row, silently dropping Vingegaard (2nd GC favourite). Now accepts a row with ≥3 decodable odds tokens.

**`feat: model team time trials in stage sim`**
- TTT scored as a team event (rank teams by aggregate TT strength, every rider takes the team placing, scored via `ttt_team_points`) instead of an individual ITT.
- Length-guarded the daily-GC-assist and final points/mountains classification loops (the scraped Tour tables are shorter than the hard-coded depths).
- Flat→hilly ProfileScore ramp starts at PS 40 (was 20) so rolling sprint stages stay majority-flat.

**`fix: show distinct riders in stage podium picks`**
- The per-stage podium columns now show three distinct riders (a dominant favourite was the modal occupant of 1st, 2nd AND 3rd), plus a note that per-stage odds exclude breakaways.

## Testing
- Full test suite passes.
- 2026 Tour stage-race report regenerates cleanly; team total points went from ~4,700 to ~11,000 (now matching 2025 actuals — Pogačar predicted 4,214 vs his 2025 actual 4,153).

Does **not** include the experimental grand-tour cross-history / points-KOM-history work (that stays on the `gt-cross-history` branch pending further validation).